### PR TITLE
Fixed path error and moved to new function call for shazamio 

### DIFF
--- a/stream/realtime.py
+++ b/stream/realtime.py
@@ -18,7 +18,7 @@ def create_callback():
     # check create and wait when fragment should recorded
     def on_create(event):
         source_path = event.src_path
-        file_name = source_path.split(dir, 1)[1]
+        file_name = source_path.split(path_to_dir, 1)[1]
         if file_name.split(".")[1] == music_extension:
             print(f"{file_name} was just created, wait when record ends...")
 

--- a/stream/realtime.py
+++ b/stream/realtime.py
@@ -34,7 +34,7 @@ def create_callback():
 
 
 async def recognize(file_path):
-    out = await shazam.recognize_song(file_path)
+    out = await shazam.recognize(file_path)
     if "track" in out:
         with open(output_file, 'r+') as write_file:
             current_song = out["track"]["subtitle"] + " - " + out["track"]["title"]


### PR DESCRIPTION
This pull request fixes an error where the realtime.py script will try to read a non-existing variable when combining the path. 

It also updates the deprecated 'recognize_song' call to the new 'recognize' method instead. 